### PR TITLE
Fix admin video edit dialog to load selected video data

### DIFF
--- a/client/src/pages/admin-videos.tsx
+++ b/client/src/pages/admin-videos.tsx
@@ -63,6 +63,20 @@ function VideoDialog({
     companyTag: video?.companyTag || "",
   });
 
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    setFormData({
+      title: video?.title || "",
+      description: video?.description || "",
+      thumbnailUrl: video?.thumbnailUrl || "",
+      videoUrl: video?.videoUrl || "",
+      duration: video?.duration || "",
+      category: video?.category || "",
+      companyTag: video?.companyTag || "",
+    });
+  }, [video, isOpen]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     onSave(formData);


### PR DESCRIPTION
## Summary
- ensure the admin video dialog form is repopulated with the selected video's details when opened for editing

## Testing
- npm run check *(fails: existing type errors in admin-users and server email service)*

------
https://chatgpt.com/codex/tasks/task_b_68ddb09863308328be7aae1b690d3f9c