### PR TITLE
Add company tag logo support and completion normalization

### DIFF
--- a/client/src/components/email-form.tsx
+++ b/client/src/components/email-form.tsx
@@ -22,6 +22,7 @@ interface Video {
   id: string;
   title: string;
   companyTag?: string | null;
+  companyTagLogoUrl?: string | null;
 }
 
 interface EmailFormProps {
@@ -139,9 +140,20 @@ export default function EmailForm({ onEmailSent, video }: EmailFormProps) {
               <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
                 Company
               </p>
-              <div className="flex justify-center">
+              <div className="flex flex-col items-center gap-2">
+                <div className="h-12 w-12 rounded-full border border-border bg-muted/30 flex items-center justify-center overflow-hidden">
+                  {video.companyTagLogoUrl ? (
+                    <img
+                      src={video.companyTagLogoUrl}
+                      alt={`${video.companyTag} logo`}
+                      className="h-full w-full object-contain"
+                    />
+                  ) : (
+                    <Building2 className="h-5 w-5 text-muted-foreground" />
+                  )}
+                </div>
                 <Badge variant="secondary" className="flex items-center gap-2 px-3 py-1">
-                  <Building2 className="h-4 w-4" />
+                  {!video.companyTagLogoUrl && <Building2 className="h-4 w-4" />}
                   <span className="text-sm font-semibold text-foreground">{video.companyTag}</span>
                 </Badge>
               </div>

--- a/client/src/pages/admin-company-tags.tsx
+++ b/client/src/pages/admin-company-tags.tsx
@@ -30,6 +30,7 @@ export default function AdminCompanyTags() {
       name: "",
       description: "",
       isActive: true,
+      logoUrl: undefined,
     },
   });
 
@@ -39,6 +40,7 @@ export default function AdminCompanyTags() {
       name: "",
       description: "",
       isActive: true,
+      logoUrl: undefined,
     },
   });
 
@@ -111,6 +113,7 @@ export default function AdminCompanyTags() {
       name: tag.name,
       description: tag.description || "",
       isActive: tag.isActive,
+      logoUrl: tag.logoUrl || undefined,
     });
     setShowEditDialog(true);
   };
@@ -122,12 +125,21 @@ export default function AdminCompanyTags() {
   };
 
   const onCreateSubmit = (data: InsertCompanyTag) => {
-    createMutation.mutate(data);
+    createMutation.mutate({
+      ...data,
+      logoUrl: data.logoUrl?.trim() ? data.logoUrl.trim() : undefined,
+    });
   };
 
   const onEditSubmit = (data: InsertCompanyTag) => {
     if (editingTag) {
-      updateMutation.mutate({ id: editingTag.id, data });
+      updateMutation.mutate({
+        id: editingTag.id,
+        data: {
+          ...data,
+          logoUrl: data.logoUrl?.trim() ? data.logoUrl.trim() : undefined,
+        }
+      });
     }
   };
 
@@ -187,11 +199,29 @@ export default function AdminCompanyTags() {
                     <FormItem>
                       <FormLabel>Description (Optional)</FormLabel>
                       <FormControl>
-                        <Textarea 
-                          placeholder="Brief description of this company tag..." 
-                          {...field} 
+                        <Textarea
+                          placeholder="Brief description of this company tag..."
+                          {...field}
                           value={field.value || ""}
                           data-testid="input-tag-description"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={createForm.control}
+                  name="logoUrl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Logo URL (Optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="https://example.com/logo.png"
+                          {...field}
+                          value={field.value ?? ""}
+                          data-testid="input-tag-logo-url"
                         />
                       </FormControl>
                       <FormMessage />
@@ -242,14 +272,29 @@ export default function AdminCompanyTags() {
               <CardHeader>
                 <div className="flex items-center justify-between">
                   <div>
-                    <CardTitle className="text-lg" data-testid={`text-tag-name-${tag.id}`}>
-                      {tag.name}
-                    </CardTitle>
-                    {tag.description && (
-                      <CardDescription data-testid={`text-tag-description-${tag.id}`}>
-                        {tag.description}
-                      </CardDescription>
-                    )}
+                    <div className="flex items-center gap-3">
+                      <div className="h-12 w-12 flex items-center justify-center rounded-full border border-border bg-muted/30 overflow-hidden">
+                        {tag.logoUrl ? (
+                          <img
+                            src={tag.logoUrl}
+                            alt={`${tag.name} logo`}
+                            className="h-full w-full object-contain"
+                          />
+                        ) : (
+                          <Tag className="h-5 w-5 text-muted-foreground" />
+                        )}
+                      </div>
+                      <div>
+                        <CardTitle className="text-lg" data-testid={`text-tag-name-${tag.id}`}>
+                          {tag.name}
+                        </CardTitle>
+                        {tag.description && (
+                          <CardDescription data-testid={`text-tag-description-${tag.id}`}>
+                            {tag.description}
+                          </CardDescription>
+                        )}
+                      </div>
+                    </div>
                   </div>
                   <div className="flex gap-2">
                     <Button
@@ -318,11 +363,29 @@ export default function AdminCompanyTags() {
                   <FormItem>
                     <FormLabel>Description (Optional)</FormLabel>
                     <FormControl>
-                      <Textarea 
-                        placeholder="Brief description of this company tag..." 
-                        {...field} 
+                      <Textarea
+                        placeholder="Brief description of this company tag..."
+                        {...field}
                         value={field.value || ""}
                         data-testid="input-edit-tag-description"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={editForm.control}
+                name="logoUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Logo URL (Optional)</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="https://example.com/logo.png"
+                        {...field}
+                        value={field.value ?? ""}
+                        data-testid="input-edit-tag-logo-url"
                       />
                     </FormControl>
                     <FormMessage />

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -12,6 +12,8 @@ interface Video {
   thumbnailUrl: string;
   duration: string;
   category: string;
+  companyTag?: string | null;
+  companyTagLogoUrl?: string | null;
 }
 
 export default function Home() {

--- a/client/src/pages/video-player.tsx
+++ b/client/src/pages/video-player.tsx
@@ -15,6 +15,8 @@ interface AccessData {
     videoUrl: string;
     duration: string;
     category: string;
+    companyTag?: string | null;
+    companyTagLogoUrl?: string | null;
   };
   accessLog: {
     id: string;
@@ -127,9 +129,13 @@ export default function VideoPlayer() {
 
   // Progress update functions (shared across all player types)
   const updateProgress = useCallback((watchDuration: number, completionPercentage: number) => {
+    const normalizedCompletion = completionPercentage >= 95 ? 100 : completionPercentage;
     const newProgress = {
       watchDuration: Math.round(watchDuration),
-      completionPercentage: Math.max(completionPercentage, progressRef.current.completionPercentage)
+      completionPercentage: Math.min(
+        100,
+        Math.max(normalizedCompletion, progressRef.current.completionPercentage)
+      )
     };
 
     progressRef.current = newProgress;

--- a/client/src/pages/video-request.tsx
+++ b/client/src/pages/video-request.tsx
@@ -16,6 +16,7 @@ interface Video {
   duration: string;
   category: string;
   companyTag?: string | null;
+  companyTagLogoUrl?: string | null;
 }
 
 export default function VideoRequest() {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -7,6 +7,7 @@ export const companyTags = pgTable("company_tags", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull().unique(),
   description: text("description"),
+  logoUrl: text("logo_url"),
   isActive: boolean("is_active").notNull().default(true),
   createdAt: timestamp("created_at").notNull().default(sql`now()`),
 });
@@ -86,6 +87,14 @@ export const accessLogsRelations = relations(accessLogs, ({ one }) => ({
 export const insertCompanyTagSchema = createInsertSchema(companyTags).omit({
   id: true,
   createdAt: true,
+}).extend({
+  logoUrl: z
+    .string()
+    .trim()
+    .url("Please enter a valid logo URL")
+    .optional()
+    .or(z.literal(""))
+    .transform((value) => (value ? value : undefined)),
 });
 
 export const insertAdminUserSchema = createInsertSchema(adminUsers).omit({


### PR DESCRIPTION
## Summary
- add optional logo URLs to company tags in the shared schema, storage helpers, and admin management UI
- surface company tag branding in public video APIs and show the logo above the magic link request button
- normalize viewer completion updates so progress at or above 95% is treated as 100%

## Testing
- npm run check *(fails: existing TypeScript issues in admin users page and email service)*

------
https://chatgpt.com/codex/tasks/task_b_68ddea4da4e48328a3a7254c13e54f50