### PR TITLE
chore: tidy shared schema import in routes

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,14 @@ import type { Express, Request, Response } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { sendEmail, generateMagicLinkEmail } from "./services/email";
-import { requestAccessSchema, updateProgressSchema, adminLoginSchema, adminCreateUserSchema, insertVideoSchema, insertCompanyTagSchema } from "@shared/schema";
+import {
+  requestAccessSchema,
+  updateProgressSchema,
+  adminLoginSchema,
+  adminCreateUserSchema,
+  insertVideoSchema,
+  insertCompanyTagSchema,
+} from "@shared/schema";
 import { randomBytes } from "crypto";
 import bcrypt from "bcryptjs";
 import type { AdminUser } from "@shared/schema";


### PR DESCRIPTION
## Summary
- format the shared schema import in `server/routes.ts` after resolving merge markers

## Testing
- npm test
- npm run check *(fails: TypeScript errors in existing admin user page and email service)*

------
https://chatgpt.com/codex/tasks/task_b_68de009c92848328bb8732f63f4e9513