### PR TITLE
Handle optional logo URL for company tags

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -88,13 +88,17 @@ export const insertCompanyTagSchema = createInsertSchema(companyTags).omit({
   id: true,
   createdAt: true,
 }).extend({
-  logoUrl: z
-    .string()
-    .trim()
-    .url("Please enter a valid logo URL")
-    .optional()
-    .or(z.literal(""))
-    .transform((value) => (value ? value : undefined)),
+  logoUrl: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") {
+        return undefined;
+      }
+
+      const trimmed = value.trim();
+      return trimmed === "" ? undefined : trimmed;
+    },
+    z.string().url("Please enter a valid logo URL").optional(),
+  ),
 });
 
 export const insertAdminUserSchema = createInsertSchema(adminUsers).omit({


### PR DESCRIPTION
## Summary
- resolve the merge conflict in shared/schema.ts keeping the logoUrl column on company tags
- normalize blank logo URL inputs to undefined while still validating actual URLs

## Testing
- npm run check *(fails: existing TypeScript errors in client/src/pages/admin-users.tsx and server/services/email.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68de03fa47e883288057d9307506d692