### PR TITLE
Add schema guard for company tag logos and fix admin user typings

### DIFF
--- a/client/src/pages/admin-users.tsx
+++ b/client/src/pages/admin-users.tsx
@@ -48,8 +48,8 @@ function UserDialog({
   const [formData, setFormData] = useState<UserFormData>({
     email: user?.email || "",
     password: "",
-    role: user?.role || "ADMIN",
-    companyTag: user?.companyTag || "",
+    role: user?.role === "SUPER_ADMIN" ? "SUPER_ADMIN" : "ADMIN",
+    companyTag: user?.companyTag ?? "",
   });
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -209,10 +209,7 @@ export default function AdminUsers() {
 
   // Create user mutation
   const createUserMutation = useMutation({
-    mutationFn: (data: UserFormData) => apiRequest("/api/admin/users", {
-      method: "POST",
-      body: JSON.stringify(data),
-    }),
+    mutationFn: (data: UserFormData) => apiRequest("POST", "/api/admin/users", data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
       setIsUserDialogOpen(false);
@@ -232,11 +229,8 @@ export default function AdminUsers() {
 
   // Update user mutation
   const updateUserMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: UserFormData }) => 
-      apiRequest(`/api/admin/users/${id}`, {
-        method: "PATCH",
-        body: JSON.stringify(data),
-      }),
+    mutationFn: ({ id, data }: { id: string; data: UserFormData }) =>
+      apiRequest("PATCH", `/api/admin/users/${id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
       setIsUserDialogOpen(false);
@@ -257,9 +251,7 @@ export default function AdminUsers() {
 
   // Delete user mutation
   const deleteUserMutation = useMutation({
-    mutationFn: (id: string) => apiRequest(`/api/admin/users/${id}`, {
-      method: "DELETE",
-    }),
+    mutationFn: (id: string) => apiRequest("DELETE", `/api/admin/users/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
       toast({
@@ -311,7 +303,7 @@ export default function AdminUsers() {
     return <Badge variant="secondary"><Shield className="h-3 w-3 mr-1" />Admin</Badge>;
   };
 
-  const getCompanyBadge = (companyTag?: string) => {
+  const getCompanyBadge = (companyTag?: string | null) => {
     if (!companyTag) {
       return <span className="text-muted-foreground text-sm">All Companies</span>;
     }

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,5 +1,5 @@
-import { Pool, neonConfig } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-serverless';
+import { Pool, neonConfig } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-serverless";
 import ws from "ws";
 import * as schema from "@shared/schema";
 
@@ -15,9 +15,32 @@ if (!databaseUrl) {
 }
 
 // Log which database we're connecting to (for debugging)
-console.log(`🔗 Connecting to database: Neon PostgreSQL`);
-const hostname = databaseUrl.match(/@([^/]+)/)?.[1] || 'unknown';
+console.log("🔗 Connecting to database: Neon PostgreSQL");
+const hostname = databaseUrl.match(/@([^/]+)/)?.[1] || "unknown";
 console.log(`🔗 Database host: ${hostname}`);
 
 export const pool = new Pool({ connectionString: databaseUrl });
 export const db = drizzle({ client: pool, schema });
+
+export async function ensureDatabaseSchema(): Promise<void> {
+  const client = await pool.connect();
+
+  try {
+    const { rows } = await client.query<{ column_name: string }>(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'company_tags' AND column_name = 'logo_url'",
+    );
+
+    if (rows.length === 0) {
+      console.warn(
+        "⚠️ Missing logo_url column on company_tags. Attempting to add it automatically...",
+      );
+      await client.query("ALTER TABLE company_tags ADD COLUMN logo_url text");
+      console.log("✅ Added logo_url column to company_tags table");
+    }
+  } catch (error) {
+    console.error("❌ Failed to ensure database schema:", error);
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import session from "express-session";
 import connectPgSimple from "connect-pg-simple";
 import { registerRoutes } from "./routes";
+import { ensureDatabaseSchema } from "./db";
 import { setupVite, serveStatic, log } from "./vite";
 
 // Validate required environment variables for production
@@ -114,54 +115,62 @@ app.use((req, res, next) => {
 });
 
 (async () => {
-  const server = await registerRoutes(app);
+  try {
+    await ensureDatabaseSchema();
+    const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, next: NextFunction) => {
-    // Prevent double-send errors if headers were already sent
-    if (res.headersSent) {
-      return next(err);
+    app.use((err: any, _req: Request, res: Response, next: NextFunction) => {
+      // Prevent double-send errors if headers were already sent
+      if (res.headersSent) {
+        return next(err);
+      }
+
+      const status = err.status || err.statusCode || 500;
+      const message = err.message || "Internal Server Error";
+
+      console.error(`❌ Request error:`, err);
+      res.status(status).json({ message });
+    });
+
+    // importantly only setup vite in development and after
+    // setting up all the other routes so the catch-all route
+    // doesn't interfere with the other routes
+    if (app.get("env") === "development") {
+      await setupVite(app, server);
+    } else {
+      serveStatic(app);
     }
 
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
+    // ALWAYS serve the app on the port specified in the environment variable PORT
+    // Other ports are firewalled. Default to 5000 if not specified.
+    // this serves both the API and the client.
+    // It is the only port that is not firewalled.
+    const port = parseInt(process.env.PORT || "5000", 10);
 
-    console.error(`❌ Request error:`, err);
-    res.status(status).json({ message });
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
-    await setupVite(app, server);
-  } else {
-    serveStatic(app);
-  }
-
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || '5000', 10);
-  
-  // Validate port number
-  if (isNaN(port) || port < 1 || port > 65535) {
-    console.error(`❌ Invalid PORT environment variable: ${process.env.PORT}. Must be a number between 1 and 65535.`);
-    process.exit(1);
-  }
-  
-  server.listen({
-    port,
-    host: "0.0.0.0",
-  }, () => {
-    log(`serving on port ${port}`);
-  }).on('error', (error: any) => {
-    console.error(`❌ Failed to start server on port ${port}:`, error.message);
-    if (error.code === 'EADDRINUSE') {
-      console.error(`   Port ${port} is already in use. Please set a different PORT environment variable.`);
-    } else if (error.code === 'EACCES') {
-      console.error(`   Permission denied to bind to port ${port}. Try using a port number above 1024.`);
+    // Validate port number
+    if (isNaN(port) || port < 1 || port > 65535) {
+      console.error(
+        `❌ Invalid PORT environment variable: ${process.env.PORT}. Must be a number between 1 and 65535.`,
+      );
+      process.exit(1);
     }
+  
+    server.listen({
+      port,
+      host: "0.0.0.0",
+    }, () => {
+      log(`serving on port ${port}`);
+    }).on('error', (error: any) => {
+      console.error(`❌ Failed to start server on port ${port}:`, error.message);
+      if (error.code === 'EADDRINUSE') {
+        console.error(`   Port ${port} is already in use. Please set a different PORT environment variable.`);
+      } else if (error.code === 'EACCES') {
+        console.error(`   Permission denied to bind to port ${port}. Try using a port number above 1024.`);
+      }
+      process.exit(1);
+    });
+  } catch (error) {
+    console.error("❌ Failed to start server:", error);
     process.exit(1);
-  });
+  }
 })();

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -89,6 +89,7 @@ export async function sendEmail(params: EmailParams): Promise<boolean> {
       subject: params.subject,
       text: params.text,
       html: params.html,
+      react: null,
     });
 
     if (error) {


### PR DESCRIPTION
## Summary
- add an automatic schema check that backfills the company_tags.logo_url column when missing
- ensure the server waits for the schema guard before registering routes and logs start-up errors clearly
- align the admin user management UI with the apiRequest helper signature and clean up type handling
- satisfy Resend typings by providing a null React payload when sending HTML emails

## Testing
- npm run test
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68de08f999548328aeff834dea820d75