### PR TITLE
Add supervisor role management and rename company admin views

### DIFF
--- a/client/src/pages/admin-company-tags.tsx
+++ b/client/src/pages/admin-company-tags.tsx
@@ -54,14 +54,14 @@ export default function AdminCompanyTags() {
       }).then(res => res.json()),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/company-tags"] });
-      toast({ description: "Company tag created successfully" });
+      toast({ description: "Company created successfully" });
       setShowCreateDialog(false);
       createForm.reset();
     },
     onError: () => {
-      toast({ 
+      toast({
         variant: "destructive",
-        description: "Failed to create company tag" 
+        description: "Failed to create company"
       });
     },
   });
@@ -76,15 +76,15 @@ export default function AdminCompanyTags() {
       }).then(res => res.json()),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/company-tags"] });
-      toast({ description: "Company tag updated successfully" });
+      toast({ description: "Company updated successfully" });
       setShowEditDialog(false);
       setEditingTag(null);
       editForm.reset();
     },
     onError: () => {
-      toast({ 
+      toast({
         variant: "destructive",
-        description: "Failed to update company tag" 
+        description: "Failed to update company"
       });
     },
   });
@@ -97,12 +97,12 @@ export default function AdminCompanyTags() {
       }).then(res => res.json()),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/company-tags"] });
-      toast({ description: "Company tag deleted successfully" });
+      toast({ description: "Company deleted successfully" });
     },
     onError: () => {
-      toast({ 
+      toast({
         variant: "destructive",
-        description: "Failed to delete company tag" 
+        description: "Failed to delete company"
       });
     },
   });
@@ -157,21 +157,21 @@ export default function AdminCompanyTags() {
     <div className="p-6" data-testid="company-tags-page">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h2 className="text-3xl font-bold text-foreground" data-testid="page-title">Company Tags</h2>
+          <h2 className="text-3xl font-bold text-foreground" data-testid="page-title">Companies</h2>
           <p className="text-muted-foreground" data-testid="page-description">
-            Manage company tags for multi-tenant access control and organization
+            Manage companies for multi-tenant access control and organization
           </p>
         </div>
         <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
           <DialogTrigger asChild>
             <Button data-testid="button-create-tag">
               <Plus className="h-4 w-4 mr-2" />
-              Create Tag
+              Create Company
             </Button>
           </DialogTrigger>
           <DialogContent data-testid="dialog-create-tag">
             <DialogHeader>
-              <DialogTitle>Create Company Tag</DialogTitle>
+              <DialogTitle>Create Company</DialogTitle>
             </DialogHeader>
             <Form {...createForm}>
               <form onSubmit={createForm.handleSubmit(onCreateSubmit)} className="space-y-4">
@@ -180,10 +180,10 @@ export default function AdminCompanyTags() {
                   name="name"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Tag Name</FormLabel>
+                      <FormLabel>Company Name</FormLabel>
                       <FormControl>
-                        <Input 
-                          placeholder="e.g., acme-corp" 
+                        <Input
+                          placeholder="e.g., Acme Corporation"
                           {...field} 
                           data-testid="input-tag-name"
                         />
@@ -200,7 +200,7 @@ export default function AdminCompanyTags() {
                       <FormLabel>Description (Optional)</FormLabel>
                       <FormControl>
                         <Textarea
-                          placeholder="Brief description of this company tag..."
+                          placeholder="Brief description of this company..."
                           {...field}
                           value={field.value || ""}
                           data-testid="input-tag-description"
@@ -234,7 +234,7 @@ export default function AdminCompanyTags() {
                     disabled={createMutation.isPending}
                     data-testid="button-submit-create"
                   >
-                    {createMutation.isPending ? "Creating..." : "Create Tag"}
+                    {createMutation.isPending ? "Creating..." : "Create Company"}
                   </Button>
                   <Button 
                     type="button" 
@@ -256,13 +256,13 @@ export default function AdminCompanyTags() {
           <Card data-testid="empty-state">
             <CardContent className="flex flex-col items-center justify-center py-16">
               <Tag className="h-12 w-12 text-muted-foreground mb-4" />
-              <h3 className="text-lg font-semibold mb-2">No Company Tags</h3>
+              <h3 className="text-lg font-semibold mb-2">No Companies</h3>
               <p className="text-muted-foreground text-center mb-4">
-                Create your first company tag to enable multi-tenant access control
+                Create your first company to enable multi-tenant access control
               </p>
               <Button onClick={() => setShowCreateDialog(true)} data-testid="button-create-first-tag">
                 <Plus className="h-4 w-4 mr-2" />
-                Create First Tag
+                Create First Company
               </Button>
             </CardContent>
           </Card>
@@ -335,7 +335,7 @@ export default function AdminCompanyTags() {
       <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
         <DialogContent data-testid="dialog-edit-tag">
           <DialogHeader>
-            <DialogTitle>Edit Company Tag</DialogTitle>
+            <DialogTitle>Edit Company</DialogTitle>
           </DialogHeader>
           <Form {...editForm}>
             <form onSubmit={editForm.handleSubmit(onEditSubmit)} className="space-y-4">
@@ -344,11 +344,11 @@ export default function AdminCompanyTags() {
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Tag Name</FormLabel>
+                    <FormLabel>Company Name</FormLabel>
                     <FormControl>
-                      <Input 
-                        placeholder="e.g., acme-corp" 
-                        {...field} 
+                      <Input
+                        placeholder="e.g., Acme Corporation"
+                        {...field}
                         data-testid="input-edit-tag-name"
                       />
                     </FormControl>
@@ -364,7 +364,7 @@ export default function AdminCompanyTags() {
                     <FormLabel>Description (Optional)</FormLabel>
                     <FormControl>
                       <Textarea
-                        placeholder="Brief description of this company tag..."
+                        placeholder="Brief description of this company..."
                         {...field}
                         value={field.value || ""}
                         data-testid="input-edit-tag-description"
@@ -398,7 +398,7 @@ export default function AdminCompanyTags() {
                   disabled={updateMutation.isPending}
                   data-testid="button-submit-edit"
                 >
-                  {updateMutation.isPending ? "Updating..." : "Update Tag"}
+                  {updateMutation.isPending ? "Updating..." : "Update Company"}
                 </Button>
                 <Button 
                   type="button" 

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -29,8 +29,8 @@ function AdminLayout({ children }: { children: React.ReactNode }) {
     { name: "Videos", href: "/admin/videos", icon: Video },
     { name: "Completions", href: "/admin/completions", icon: BarChart3 },
     ...(adminUser?.role === "SUPER_ADMIN" ? [
-      { name: "Users", href: "/admin/users", icon: Users },
-      { name: "Company Tags", href: "/admin/company-tags", icon: Tag }
+      { name: "Team", href: "/admin/users", icon: Users },
+      { name: "Companies", href: "/admin/company-tags", icon: Tag }
     ] : []),
   ];
 

--- a/client/src/pages/admin-users.tsx
+++ b/client/src/pages/admin-users.tsx
@@ -23,10 +23,12 @@ import {
 } from "lucide-react";
 import type { AdminUser, CompanyTag } from "@shared/schema";
 
+type UserRoleOption = "SUPER_ADMIN" | "SUPERVISOR";
+
 interface UserFormData {
   email: string;
   password: string;
-  role: "ADMIN" | "SUPER_ADMIN";
+  role: UserRoleOption;
   companyTag?: string;
 }
 
@@ -45,10 +47,11 @@ function UserDialog({
   const { data: companyTags = [] } = useQuery<CompanyTag[]>({
     queryKey: ["/api/admin/company-tags"],
   });
+  const initialRole: UserRoleOption = user?.role === "SUPER_ADMIN" ? "SUPER_ADMIN" : "SUPERVISOR";
   const [formData, setFormData] = useState<UserFormData>({
     email: user?.email || "",
     password: "",
-    role: user?.role === "SUPER_ADMIN" ? "SUPER_ADMIN" : "ADMIN",
+    role: initialRole,
     companyTag: user?.companyTag ?? "",
   });
 
@@ -103,20 +106,20 @@ function UserDialog({
             <Label htmlFor="role">Role</Label>
             <Select
               value={formData.role}
-              onValueChange={(value: "ADMIN" | "SUPER_ADMIN") => handleChange("role", value)}
+              onValueChange={(value: UserRoleOption) => handleChange("role", value)}
             >
               <SelectTrigger data-testid="select-user-role">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="ADMIN">Admin</SelectItem>
-                <SelectItem value="SUPER_ADMIN">Super Admin</SelectItem>
+                <SelectItem value="SUPERVISOR">Supervisor</SelectItem>
+                <SelectItem value="SUPER_ADMIN">Admin</SelectItem>
               </SelectContent>
             </Select>
           </div>
           
           <div className="space-y-2">
-            <Label htmlFor="companyTag">Company Tag (for ADMINs)</Label>
+            <Label htmlFor="companyTag">Company (for Supervisors)</Label>
             {companyTags.length > 0 ? (
               <Select
                 value={formData.companyTag || "none"}
@@ -128,7 +131,7 @@ function UserDialog({
                   <SelectValue placeholder="Select a company tag" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">No company tag</SelectItem>
+                  <SelectItem value="none">No company (all companies)</SelectItem>
                   {companyTags.map((tag) => (
                     <SelectItem key={tag.id} value={tag.name}>
                       {tag.name}
@@ -146,9 +149,9 @@ function UserDialog({
                 data-testid="input-user-company-tag"
               />
             )}
-            {formData.role === "ADMIN" && (
+            {formData.role === "SUPERVISOR" && (
               <p className="text-xs text-muted-foreground">
-                Admins will only see videos and completions for this company tag
+                Supervisors will only see videos and completions for their assigned company
               </p>
             )}
             {formData.role === "SUPER_ADMIN" && (
@@ -183,9 +186,9 @@ export default function AdminUsers() {
     return (
       <div className="space-y-6">
         <div>
-          <h2 className="text-3xl font-bold text-foreground">Users</h2>
+          <h2 className="text-3xl font-bold text-foreground">Team Members</h2>
           <p className="text-muted-foreground">
-            Manage admin users and company assignments
+            Manage admins, supervisors and company assignments
           </p>
         </div>
         
@@ -202,7 +205,7 @@ export default function AdminUsers() {
     );
   }
 
-  // Fetch admin users
+  // Fetch team members
   const { data: users = [], isLoading } = useQuery<Omit<AdminUser, 'password'>[]>({
     queryKey: ["/api/admin/users"],
   });
@@ -214,8 +217,8 @@ export default function AdminUsers() {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
       setIsUserDialogOpen(false);
       toast({
-        title: "User Created",
-        description: "The admin user has been created successfully.",
+        title: "Team Member Created",
+        description: "The team member has been created successfully.",
       });
     },
     onError: (error: any) => {
@@ -236,8 +239,8 @@ export default function AdminUsers() {
       setIsUserDialogOpen(false);
       setEditingUser(undefined);
       toast({
-        title: "User Updated",
-        description: "The admin user has been updated successfully.",
+        title: "Team Member Updated",
+        description: "The team member has been updated successfully.",
       });
     },
     onError: (error: any) => {
@@ -255,8 +258,8 @@ export default function AdminUsers() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
       toast({
-        title: "User Deleted",
-        description: "The admin user has been removed successfully.",
+        title: "Team Member Removed",
+        description: "The team member has been removed successfully.",
       });
     },
     onError: (error: any) => {
@@ -269,10 +272,15 @@ export default function AdminUsers() {
   });
 
   const handleSaveUser = (data: UserFormData) => {
+    const normalizedData: UserFormData = {
+      ...data,
+      companyTag: data.role === "SUPER_ADMIN" ? undefined : (data.companyTag?.trim() ? data.companyTag.trim() : undefined),
+    };
+
     if (editingUser) {
-      updateUserMutation.mutate({ id: editingUser.id, data });
+      updateUserMutation.mutate({ id: editingUser.id, data: normalizedData });
     } else {
-      createUserMutation.mutate(data);
+      createUserMutation.mutate(normalizedData);
     }
   };
 
@@ -291,16 +299,16 @@ export default function AdminUsers() {
       return;
     }
     
-    if (confirm(`Are you sure you want to delete the admin user "${user.email}"?`)) {
+    if (confirm(`Are you sure you want to remove the team member "${user.email}"?`)) {
       deleteUserMutation.mutate(user.id);
     }
   };
 
   const getRoleBadge = (role: string) => {
     if (role === "SUPER_ADMIN") {
-      return <Badge className="bg-purple-100 text-purple-800"><Crown className="h-3 w-3 mr-1" />Super Admin</Badge>;
+      return <Badge className="bg-purple-100 text-purple-800"><Crown className="h-3 w-3 mr-1" />Admin</Badge>;
     }
-    return <Badge variant="secondary"><Shield className="h-3 w-3 mr-1" />Admin</Badge>;
+    return <Badge variant="secondary"><Shield className="h-3 w-3 mr-1" />Supervisor</Badge>;
   };
 
   const getCompanyBadge = (companyTag?: string | null) => {
@@ -314,8 +322,8 @@ export default function AdminUsers() {
     return (
       <div className="space-y-6">
         <div>
-          <h2 className="text-3xl font-bold text-foreground">Users</h2>
-          <p className="text-muted-foreground">Loading admin users...</p>
+          <h2 className="text-3xl font-bold text-foreground">Team Members</h2>
+          <p className="text-muted-foreground">Loading team members...</p>
         </div>
         <div className="space-y-4">
           {[1, 2, 3].map((i) => (
@@ -335,15 +343,15 @@ export default function AdminUsers() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-3xl font-bold text-foreground">Users</h2>
+          <h2 className="text-3xl font-bold text-foreground">Team Members</h2>
           <p className="text-muted-foreground">
-            Manage admin users and company assignments ({users.length} user{users.length !== 1 ? 's' : ''})
+            Manage admins and supervisors ({users.length} member{users.length !== 1 ? 's' : ''})
           </p>
         </div>
-        
+
         <Button onClick={() => setIsUserDialogOpen(true)} data-testid="button-add-user">
           <Plus className="h-4 w-4 mr-2" />
-          Add Admin User
+          Add Team Member
         </Button>
       </div>
 
@@ -360,15 +368,15 @@ export default function AdminUsers() {
             </div>
           </CardContent>
         </Card>
-        
+
         <Card>
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
               <Shield className="h-4 w-4 text-blue-600" />
-              <span className="text-sm font-medium">Admins</span>
+              <span className="text-sm font-medium">Supervisors</span>
             </div>
             <div className="text-2xl font-bold text-blue-600">
-              {users.filter(u => u.role === "ADMIN").length}
+              {users.filter(u => u.role === "SUPERVISOR" || u.role === "ADMIN").length}
             </div>
           </CardContent>
         </Card>
@@ -391,13 +399,13 @@ export default function AdminUsers() {
         <Card>
           <CardContent className="text-center py-12">
             <User className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-foreground mb-2">No admin users yet</h3>
+            <h3 className="text-lg font-semibold text-foreground mb-2">No team members yet</h3>
             <p className="text-muted-foreground mb-4">
-              Create admin users to manage different aspects of the platform.
+              Create team members to manage companies and training content.
             </p>
             <Button onClick={() => setIsUserDialogOpen(true)}>
               <Plus className="h-4 w-4 mr-2" />
-              Add Admin User
+              Add Team Member
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- extend admin user schema to support supervisor roles and shared validators
- normalize admin user create/update routes and adjust company assignment handling
- refresh admin management screens with supervisor-focused language and company terminology

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68df158624b88328a8b320cc4e4b0512