### PR TITLE
Restrict supervisor data access and streamline admin UI

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -28,15 +28,17 @@ function AdminLayout({ children }: { children: React.ReactNode }) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const navigation = [
+    ...(adminUser?.role === "SUPER_ADMIN"
+      ? [
+          { name: "Admin Users", href: "/admin/users", icon: Users },
+          { name: "Companies", href: "/admin/company-tags", icon: Tag },
+        ]
+      : []),
+    ...((adminUser?.role === "SUPER_ADMIN" || adminUser?.role === "ADMIN")
+      ? [{ name: "Supervisors", href: "/admin/supervisors", icon: UserCog }]
+      : []),
     { name: "Videos", href: "/admin/videos", icon: Video },
     { name: "Completions", href: "/admin/completions", icon: BarChart3 },
-    ...((adminUser?.role === "SUPER_ADMIN" || adminUser?.role === "ADMIN") ? [
-      { name: "Supervisors", href: "/admin/supervisors", icon: UserCog },
-    ] : []),
-    ...(adminUser?.role === "SUPER_ADMIN" ? [
-      { name: "Users", href: "/admin/users", icon: Users },
-      { name: "Company Tags", href: "/admin/company-tags", icon: Tag }
-    ] : []),
   ];
 
   const handleLogout = async () => {

--- a/client/src/pages/admin-videos.tsx
+++ b/client/src/pages/admin-videos.tsx
@@ -175,7 +175,7 @@ function VideoDialog({
             </div>
             
             <div className="space-y-2">
-              <Label htmlFor="companyTag">Company Tag (Optional)</Label>
+              <Label htmlFor="companyTag">Company Tag</Label>
               {adminUser?.role === "SUPER_ADMIN" && companyTags.length > 0 ? (
                 <Select
                   value={formData.companyTag || "none"}

--- a/client/src/pages/video-request.tsx
+++ b/client/src/pages/video-request.tsx
@@ -5,7 +5,7 @@ import VideoThumbnail from "@/components/video-thumbnail";
 import EmailForm from "@/components/email-form";
 import EmailSentModal from "@/components/email-sent-modal";
 import { Button } from "@/components/ui/button";
-import { Shield, Lock, CheckCircle, LogIn, ArrowLeft } from "lucide-react";
+import { Shield, Lock, LogIn } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
 interface Video {
@@ -113,10 +113,9 @@ export default function VideoRequest() {
                 The requested training video could not be found or is no longer available.
               </p>
               <Link href="/">
-                <Button data-testid="button-back-home-error">
-                  <ArrowLeft className="h-4 w-4 mr-2" />
-                  Back to Video Selection
-                </Button>
+                <span className="text-sm font-medium text-primary" data-testid="link-back-home-error">
+                  Return to home
+                </span>
               </Link>
             </div>
           </div>
@@ -131,16 +130,6 @@ export default function VideoRequest() {
       
       <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="max-w-4xl mx-auto">
-          {/* Back to Video Selection */}
-          <div className="mb-8">
-            <Link href="/">
-              <Button variant="outline" className="mb-4" data-testid="button-back-home">
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back to Video Selection
-              </Button>
-            </Link>
-          </div>
-
           {/* Video Section - Moved to Top */}
           <div className="mb-12">
             <div className="max-w-2xl mx-auto">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -351,8 +351,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/videos", requireAdmin, async (req: Request, res: Response) => {
     try {
       const adminUser = req.session.adminUser!;
+      if (adminUser.role === "SUPERVISOR") {
+        if (!adminUser.companyTag) {
+          return res.status(403).json({ message: "Supervisor must be assigned to a company" });
+        }
+
+        const videos = await storage.getAllVideos(adminUser.companyTag);
+        return res.json(videos);
+      }
+
       const companyTag = adminUser.role === "SUPER_ADMIN" ? undefined : adminUser.companyTag || undefined;
-      
+
       const videos = await storage.getAllVideos(companyTag);
       res.json(videos);
 
@@ -437,6 +446,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/completions", requireAdmin, async (req: Request, res: Response) => {
     try {
       const adminUser = req.session.adminUser!;
+      if (adminUser.role === "SUPERVISOR") {
+        if (!adminUser.companyTag) {
+          return res.status(403).json({ message: "Supervisor must be assigned to a company" });
+        }
+
+        const completions = await storage.getAllAccessLogs(adminUser.companyTag);
+        return res.json(completions);
+      }
+
       const companyTag = adminUser.role === "SUPER_ADMIN" ? undefined : adminUser.companyTag || undefined;
 
       const completions = await storage.getAllAccessLogs(companyTag);


### PR DESCRIPTION
## Summary
- ensure supervisors are limited to viewing videos for their assigned company
- prevent supervisors from viewing completion logs outside of their assigned company
- return a clear error if a supervisor lacks a company assignment when accessing these resources
- rename and reorder admin navigation to highlight admin users, companies, supervisors, videos, and completions in that order
- remove optional text from the company tag selector and drop the back-navigation button on the video request page

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68df3ed969b083289553e2211c2e9e6f