### PR TITLE
Add home link to admin sidebar and update completion filters

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -14,7 +14,8 @@ import {
   Tag,
   Menu,
   X,
-  UserCog
+  UserCog,
+  Home,
 } from "lucide-react";
 import AdminVideos from "@/pages/admin-videos";
 import AdminCompletions from "@/pages/admin-completions";
@@ -28,6 +29,7 @@ function AdminLayout({ children }: { children: React.ReactNode }) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const navigation = [
+    { name: "Home", href: "/admin", icon: Home },
     ...(adminUser?.role === "SUPER_ADMIN"
       ? [
           { name: "Admin Users", href: "/admin/users", icon: Users },


### PR DESCRIPTION
## Summary
- add a Home navigation item so admins and supervisors can return to their dashboard from the sidebar
- replace the email domain filter with a company tag selector and limit supervisors to their assigned company data
- update completion stats, export, and table display to align with the new company tag filtering

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68df4deac42083289ab1f23aa962a381