### PR TITLE
Add sharing controls and completion email notifications

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -37,6 +37,26 @@ export async function ensureDatabaseSchema(): Promise<void> {
       await client.query("ALTER TABLE company_tags ADD COLUMN logo_url text");
       console.log("✅ Added logo_url column to company_tags table");
     }
+
+    const { rows: completionEmailColumn } = await client.query<{ column_name: string }>(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'videos' AND column_name = 'completion_email'",
+    );
+
+    if (completionEmailColumn.length === 0) {
+      console.warn("⚠️ Missing completion_email column on videos. Attempting to add it automatically...");
+      await client.query("ALTER TABLE videos ADD COLUMN completion_email text");
+      console.log("✅ Added completion_email column to videos table");
+    }
+
+    const { rows: completionNotifiedColumn } = await client.query<{ column_name: string }>(
+      "SELECT column_name FROM information_schema.columns WHERE table_name = 'access_logs' AND column_name = 'completion_notified'",
+    );
+
+    if (completionNotifiedColumn.length === 0) {
+      console.warn("⚠️ Missing completion_notified column on access_logs. Attempting to add it automatically...");
+      await client.query("ALTER TABLE access_logs ADD COLUMN completion_notified boolean NOT NULL DEFAULT false");
+      console.log("✅ Added completion_notified column to access_logs table");
+    }
   } catch (error) {
     console.error("❌ Failed to ensure database schema:", error);
     throw error;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express, Request, Response } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { sendEmail, generateMagicLinkEmail } from "./services/email";
+import { sendEmail, generateMagicLinkEmail, generateCompletionNotificationEmail } from "./services/email";
 import {
   requestAccessSchema,
   updateProgressSchema,
@@ -175,10 +175,41 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const updates = updateProgressSchema.parse(req.body);
       const normalizedCompletion = Math.min(100, updates.completionPercentage >= 95 ? 100 : updates.completionPercentage);
 
+      const existingLog = await storage.getAccessLogById(accessLogId);
+      if (!existingLog) {
+        return res.status(404).json({ message: "Access log not found" });
+      }
+
       await storage.updateAccessLog(accessLogId, {
         ...updates,
         completionPercentage: normalizedCompletion,
       });
+
+      if (
+        normalizedCompletion === 100 &&
+        !existingLog.completionNotified &&
+        (existingLog.completionPercentage ?? 0) < 100
+      ) {
+        const video = await storage.getVideo(existingLog.videoId);
+
+        if (video?.completionEmail) {
+          const emailParams = generateCompletionNotificationEmail({
+            to: video.completionEmail,
+            viewerEmail: existingLog.email,
+            viewerName: existingLog.userName,
+            videoTitle: video.title,
+            completedAt: new Date(),
+          });
+
+          const emailSent = await sendEmail(emailParams);
+
+          if (emailSent) {
+            await storage.markAccessLogCompletionNotified(accessLogId);
+          } else {
+            console.error("Failed to send completion notification email for access log", accessLogId);
+          }
+        }
+      }
 
       res.json({ message: "Progress updated successfully" });
 

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -197,3 +197,86 @@ TaskSafe Security Team
     `
   };
 }
+
+interface CompletionEmailParams {
+  to: string;
+  viewerName: string;
+  viewerEmail: string;
+  videoTitle: string;
+  completedAt: Date;
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function generateCompletionNotificationEmail({
+  to,
+  viewerName,
+  viewerEmail,
+  videoTitle,
+  completedAt,
+}: CompletionEmailParams): EmailParams {
+  const completedAtText = formatDate(completedAt);
+
+  const text = `
+Training completion notification
+
+Video: ${videoTitle}
+Viewer: ${viewerName} (${viewerEmail})
+Completed at: ${completedAtText}
+
+The viewer has successfully completed the training video.
+`;
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Training Completion Notification</title>
+</head>
+<body style="margin:0;padding:0;font-family:Arial,sans-serif;background-color:#f8fafc;">
+  <div style="max-width:600px;margin:0 auto;padding:20px;">
+    <div style="background-color:white;border-radius:8px;overflow:hidden;box-shadow:0 2px 4px rgba(0,0,0,0.1);">
+      <div style="background-color:#2563eb;padding:20px;text-align:center;color:white;">
+        <h1 style="margin:0;font-size:22px;font-weight:600;">Training Completion</h1>
+      </div>
+      <div style="padding:24px;">
+        <p style="margin:0 0 16px 0;color:#1f2937;">Hello,</p>
+        <p style="margin:0 0 16px 0;color:#4b5563;">
+          The following training video has been completed:
+        </p>
+        <div style="background-color:#f3f4f6;border-radius:6px;padding:16px;margin-bottom:16px;">
+          <p style="margin:0 0 8px 0;color:#1f2937;"><strong>Video:</strong> ${videoTitle}</p>
+          <p style="margin:0 0 8px 0;color:#1f2937;"><strong>Viewer:</strong> ${viewerName} (${viewerEmail})</p>
+          <p style="margin:0;color:#1f2937;"><strong>Completed at:</strong> ${completedAtText}</p>
+        </div>
+        <p style="margin:0;color:#6b7280;font-size:14px;">
+          This notification was sent automatically by TaskSafe when the viewer reached 100% completion.
+        </p>
+      </div>
+      <div style="background-color:#f9fafb;padding:16px;text-align:center;color:#9ca3af;font-size:12px;">
+        © ${new Date().getFullYear()} TaskSafe. All rights reserved.
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`;
+
+  return {
+    to,
+    from: 'noreply@tasksafe.au',
+    subject: `TaskSafe: ${videoTitle} completed`,
+    text,
+    html,
+  };
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -37,6 +37,7 @@ export interface IStorage {
   // Access log methods
   createAccessLog(accessLog: InsertAccessLog): Promise<AccessLog>;
   updateAccessLog(id: string, updates: { watchDuration?: number; completionPercentage?: number }): Promise<void>;
+  markAccessLogCompletionNotified(id: string): Promise<void>;
   getAccessLogsByVideo(videoId: string): Promise<AccessLog[]>;
   getAccessLogById(id: string): Promise<(AccessLog & { videoTitle: string | null; videoDuration: string | null; videoCategory: string | null }) | undefined>;
   getAllAccessLogs(companyTag?: string): Promise<(AccessLog & { videoTitle: string | null })[]>;
@@ -131,6 +132,13 @@ export class DatabaseStorage implements IStorage {
       .where(eq(accessLogs.id, id));
   }
 
+  async markAccessLogCompletionNotified(id: string): Promise<void> {
+    await db
+      .update(accessLogs)
+      .set({ completionNotified: true })
+      .where(eq(accessLogs.id, id));
+  }
+
   async getAccessLogsByVideo(videoId: string): Promise<AccessLog[]> {
     return await db.select().from(accessLogs)
       .where(eq(accessLogs.videoId, videoId))
@@ -150,6 +158,7 @@ export class DatabaseStorage implements IStorage {
       companyTag: accessLogs.companyTag,
       ipAddress: accessLogs.ipAddress,
       userAgent: accessLogs.userAgent,
+      completionNotified: accessLogs.completionNotified,
       videoTitle: videos.title,
       videoDuration: videos.duration,
       videoCategory: videos.category,
@@ -195,6 +204,7 @@ export class DatabaseStorage implements IStorage {
       companyTag: accessLogs.companyTag,
       ipAddress: accessLogs.ipAddress,
       userAgent: accessLogs.userAgent,
+      completionNotified: accessLogs.completionNotified,
       videoTitle: videos.title,
     })
     .from(accessLogs)

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -31,6 +31,7 @@ export const videos = pgTable("videos", {
   duration: text("duration").notNull(), // e.g., "12:34"
   category: text("category").notNull(),
   companyTag: text("company_tag"), // for role-based access
+  completionEmail: text("completion_email"),
   isActive: boolean("is_active").notNull().default(true),
   createdAt: timestamp("created_at").notNull().default(sql`now()`),
 });
@@ -58,6 +59,7 @@ export const accessLogs = pgTable("access_logs", {
   companyTag: text("company_tag"), // derived from email domain or video
   ipAddress: text("ip_address"),
   userAgent: text("user_agent"),
+  completionNotified: boolean("completion_notified").notNull().default(false),
 });
 
 export const videosRelations = relations(videos, ({ many }) => ({
@@ -109,6 +111,22 @@ export const insertAdminUserSchema = createInsertSchema(adminUsers).omit({
 export const insertVideoSchema = createInsertSchema(videos).omit({
   id: true,
   createdAt: true,
+}).extend({
+  completionEmail: z.preprocess(
+    (value) => {
+      if (typeof value !== "string") {
+        return value ?? null;
+      }
+
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    },
+    z
+      .string()
+      .email("Please enter a valid email address")
+      .nullable()
+      .optional(),
+  ),
 });
 
 export const insertMagicLinkSchema = createInsertSchema(magicLinks).omit({


### PR DESCRIPTION
## Summary
- add a web share button beside each admin video card's copy link control and provide in-place inputs to manage completion notification emails
- extend video management forms and database schema to persist per-video completion notification recipients and track whether notifications were sent
- trigger completion emails when viewers reach 100% progress, using the new email template and marking access logs as notified

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68df598e44b883289c37f8c393c0aa6e