### PR TITLE
Tighten company scoping for admin and supervisor dashboards

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -382,12 +382,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/videos", requireAdmin, async (req: Request, res: Response) => {
     try {
       const adminUser = req.session.adminUser!;
-      if (adminUser.role === "SUPERVISOR") {
-        if (!adminUser.companyTag) {
-          return res.status(403).json({ message: "Supervisor must be assigned to a company" });
+      const normalizedCompanyTag = adminUser.companyTag?.trim() || null;
+
+      if (adminUser.role !== "SUPER_ADMIN") {
+        if (!normalizedCompanyTag) {
+          return res.status(403).json({ message: "Company assignment required" });
         }
 
-        const videos = await storage.getAllVideos(adminUser.companyTag);
+        const videos = await storage.getAllVideos(normalizedCompanyTag);
         return res.json(videos);
       }
 
@@ -475,12 +477,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/completions", requireAdmin, async (req: Request, res: Response) => {
     try {
       const adminUser = req.session.adminUser!;
-      if (adminUser.role === "SUPERVISOR") {
-        if (!adminUser.companyTag) {
-          return res.status(403).json({ message: "Supervisor must be assigned to a company" });
+      const normalizedCompanyTag = adminUser.companyTag?.trim() || null;
+
+      if (adminUser.role !== "SUPER_ADMIN") {
+        if (!normalizedCompanyTag) {
+          return res.status(403).json({ message: "Company assignment required" });
         }
 
-        const completions = await storage.getAllAccessLogs(adminUser.companyTag);
+        const completions = await storage.getAllAccessLogs(normalizedCompanyTag);
         return res.json(completions);
       }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -173,7 +173,10 @@ export class DatabaseStorage implements IStorage {
   async getAllVideos(companyTag?: string): Promise<Video[]> {
     const query = db.select().from(videos);
     if (companyTag) {
-      return await query.where(eq(videos.companyTag, companyTag)).orderBy(desc(videos.createdAt));
+      const normalizedTag = companyTag.trim();
+      return await query
+        .where(eq(videos.companyTag, normalizedTag))
+        .orderBy(desc(videos.createdAt));
     }
     return await query.orderBy(desc(videos.createdAt));
   }
@@ -211,7 +214,15 @@ export class DatabaseStorage implements IStorage {
     .leftJoin(videos, eq(accessLogs.videoId, videos.id));
 
     if (companyTag) {
-      return await query.where(eq(videos.companyTag, companyTag)).orderBy(desc(accessLogs.accessedAt));
+      const normalizedTag = companyTag.trim();
+      return await query
+        .where(
+          or(
+            eq(videos.companyTag, normalizedTag),
+            eq(accessLogs.companyTag, normalizedTag),
+          ),
+        )
+        .orderBy(desc(accessLogs.accessedAt));
     }
     return await query.orderBy(desc(accessLogs.accessedAt));
   }


### PR DESCRIPTION
## Summary
- require non-super-admin roles to have a company tag before returning admin video and completion data and reuse the scoped tag for filtering
- normalize company tags in storage helpers so video and completion queries only return records for the assigned organization, including historical access logs

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68df679593e0832896b2fe724a31642f