### PR TITLE
Remove Render domain reference from email URL test

### DIFF
--- a/server/services/email.test.ts
+++ b/server/services/email.test.ts
@@ -72,8 +72,8 @@ const cases: TestCase[] = [
   },
   {
     name: 'falls back to Render external URL',
-    env: { RENDER_EXTERNAL_URL: 'https://service.onrender.com' },
-    expectedBase: 'https://service.onrender.com',
+    env: { RENDER_EXTERNAL_URL: 'https://render.example.com' },
+    expectedBase: 'https://render.example.com',
   },
   {
     name: 'normalizes provider URL without protocol',


### PR DESCRIPTION
## Summary
- replace the Render fallback URL in the magic-link email test with a neutral example domain to eliminate onrender references

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e0593599008328b2aa6d4b51fb2650