### PR TITLE
Prefer tasksafe.au domain for magic links

### DIFF
--- a/server/services/email.test.ts
+++ b/server/services/email.test.ts
@@ -71,9 +71,9 @@ const cases: TestCase[] = [
     expectedBase: 'https://custom.example',
   },
   {
-    name: 'falls back to Render external URL',
-    env: { RENDER_EXTERNAL_URL: 'https://render.example.com' },
-    expectedBase: 'https://render.example.com',
+    name: 'prefers TaskSafe domain over Render default host',
+    env: { RENDER_EXTERNAL_URL: 'https://tasksafe.onrender.com' },
+    expectedBase: 'https://tasksafe.au',
   },
   {
     name: 'normalizes provider URL without protocol',

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -4,6 +4,7 @@ import { Resend } from 'resend';
 const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
 const FALLBACK_LOCAL_HOST = 'localhost:5000';
+const TASKSAFE_PRIMARY_DOMAIN = 'https://tasksafe.au';
 
 const DEPLOYMENT_ENV_KEYS = [
   'MAGIC_LINK_BASE_URL',
@@ -37,10 +38,22 @@ function normalizeBaseUrl(
   return `${protocol}://${trimmed}`;
 }
 
+function isRenderHostname(baseUrl: string): boolean {
+  try {
+    const { hostname } = new URL(baseUrl);
+    return hostname.endsWith('.onrender.com');
+  } catch {
+    return false;
+  }
+}
+
 function resolveMagicLinkBaseUrl(): string {
   for (const key of DEPLOYMENT_ENV_KEYS) {
     const normalized = normalizeBaseUrl(process.env[key]);
     if (normalized) {
+      if (key === 'RENDER_EXTERNAL_URL' && isRenderHostname(normalized)) {
+        return TASKSAFE_PRIMARY_DOMAIN;
+      }
       return normalized;
     }
   }


### PR DESCRIPTION
## Summary
- ensure Render-provided base URLs are replaced with the tasksafe.au domain when building magic links
- add a regression test covering the updated domain selection logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e0673196f48328afdb9618f8fffb47