### PR TITLE
Hide export CSV button on mobile

### DIFF
--- a/client/src/pages/admin-completions.tsx
+++ b/client/src/pages/admin-completions.tsx
@@ -316,6 +316,7 @@ export default function AdminCompletions() {
             onClick={exportToCSV}
             disabled={filteredCompletions.length === 0}
             data-testid="button-export-csv"
+            className="hidden sm:inline-flex"
           >
             <DownloadIcon className="h-4 w-4 mr-2" />
             Export CSV


### PR DESCRIPTION
## Summary
- hide the export CSV button on the completions page for small screen widths by applying a responsive utility class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e09791938c8328a9f6f3234bf4db3d